### PR TITLE
Model context

### DIFF
--- a/Weather-DVT.xcodeproj/project.pbxproj
+++ b/Weather-DVT.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		04059B692E632AE100011811 /* Weather-DVT.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Weather-DVT.xctestplan"; sourceTree = "<group>"; };
 		04DCD2972E59EA7500216A0D /* Weather-DVT.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Weather-DVT.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		04DCD2A52E59EA7700216A0D /* Weather-DVTTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Weather-DVTTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		04DCD2AF2E59EA7700216A0D /* Weather-DVTUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Weather-DVTUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -93,6 +94,7 @@
 		04DCD28E2E59EA7500216A0D = {
 			isa = PBXGroup;
 			children = (
+				04059B692E632AE100011811 /* Weather-DVT.xctestplan */,
 				04DCD3082E5B71CB00216A0D /* secrets.xcconfig */,
 				04DCD2992E59EA7500216A0D /* Weather-DVT */,
 				04DCD2A82E59EA7700216A0D /* Weather-DVTTests */,

--- a/Weather-DVT.xcodeproj/xcshareddata/xcschemes/Weather-DVT.xcscheme
+++ b/Weather-DVT.xcodeproj/xcshareddata/xcschemes/Weather-DVT.xcscheme
@@ -27,8 +27,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Weather-DVT.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO"
@@ -42,8 +47,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "04DCD2AE2E59EA7700216A0D"

--- a/Weather-DVT.xctestplan
+++ b/Weather-DVT.xctestplan
@@ -1,0 +1,42 @@
+{
+  "configurations" : [
+    {
+      "id" : "58259F6F-6B4D-4E43-8C8C-1862625B3372",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "environmentVariableEntries" : [
+      {
+        "key" : "API_KEY",
+        "value" : "$(API_KEY)"
+      }
+    ],
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:Weather-DVT.xcodeproj",
+      "identifier" : "04DCD2962E59EA7500216A0D",
+      "name" : "Weather-DVT"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:Weather-DVT.xcodeproj",
+        "identifier" : "04DCD2A42E59EA7700216A0D",
+        "name" : "Weather-DVTTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Weather-DVT.xcodeproj",
+        "identifier" : "04DCD2AE2E59EA7700216A0D",
+        "name" : "Weather-DVTUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Weather-DVT/Core/Services/PersistenceService.swift
+++ b/Weather-DVT/Core/Services/PersistenceService.swift
@@ -78,6 +78,8 @@ final class DefaultPersistenceService: PersistenceService {
             forecast.location = locationToUpdate
             locationToUpdate.forecast.append(forecast)
         }
+
+        try? modelContext.save()
     }
 
     private func findOrCreateLocation(for location: WeatherLocation) -> CachedLocation? {

--- a/Weather-DVT/Core/Services/PersistenceService.swift
+++ b/Weather-DVT/Core/Services/PersistenceService.swift
@@ -8,6 +8,16 @@
 import Foundation
 import SwiftData
 
+protocol ModelContextProtocol {
+    func fetch<T>(_ descriptor: FetchDescriptor<T>) throws -> [T] where T: PersistentModel
+    func fetchCount<T>(_ descriptor: FetchDescriptor<T>) throws -> Int where T: PersistentModel
+    func insert<T>(_ model: T) where T: PersistentModel
+    func delete<T>(_ model: T) where T : PersistentModel
+    func save() throws
+}
+
+extension ModelContext: ModelContextProtocol {}
+
 @MainActor
 protocol  PersistenceService {
     func fetchCachedWeather(for location: WeatherLocation) -> CachedLocation?
@@ -17,9 +27,9 @@ protocol  PersistenceService {
 
 @MainActor
 final class DefaultPersistenceService: PersistenceService {
-    private let modelContext: ModelContext
+    private let modelContext: ModelContextProtocol
 
-    init(modelContext: ModelContext) {
+    init(modelContext: ModelContextProtocol) {
         self.modelContext = modelContext
     }
 

--- a/Weather-DVT/Models/Forecast.swift
+++ b/Weather-DVT/Models/Forecast.swift
@@ -7,8 +7,7 @@
 
 import Foundation
 
-struct Forecast: Identifiable {
-    let id = UUID()
+struct Forecast {
     let date: Date
     let city: String
     let list: [Weather]

--- a/Weather-DVTTests/Mocks/MockAPIData.swift
+++ b/Weather-DVTTests/Mocks/MockAPIData.swift
@@ -1,0 +1,63 @@
+//
+//  MockAPIData.swift
+//  Weather-DVTTests
+//
+//  Created by Sylvan  on 30/08/2025.
+//
+
+import Foundation
+
+struct MockAPIData {
+
+    static let currentWeatherJSON = """
+    {
+        "weather": [
+            {
+                "main": "Snow",
+                "description": "clear sky",
+                "icon": "01d"
+            }
+        ],
+        "main": {
+            "temp": 25.45,
+            "temp_min": 22.1,
+            "temp_max": 28.9
+        },
+        "dt": 1661870592
+    }
+    """.data(using: .utf8)!
+
+    // An edge case to test `weather.first?` logic
+    static let currentWeatherEmptyWeatherArrayJSON = """
+    {
+        "weather": [],
+        "main": {
+            "temp": 15.0,
+            "temp_min": 12.0,
+            "temp_max": 18.0
+        },
+        "dt": 1661870600
+    }
+    """.data(using: .utf8)!
+
+    static let forecast5DaysJSON = """
+    {
+        "city": {
+            "id": 123,
+            "name": "Mountain View"
+        },
+        "list": [
+            {
+                "dt": 1661870592,
+                "main": { "temp": 25.45, "temp_min": 22.1, "temp_max": 28.9 },
+                "weather": [{ "main": "Atmosphere" }]
+            },
+            {
+                "dt": 1661956992,
+                "main": { "temp": 18.2, "temp_min": 15.0, "temp_max": 20.5 },
+                "weather": [{ "main": "Drizzle" }]
+            }
+        ]
+    }
+    """.data(using: .utf8)!
+}

--- a/Weather-DVTTests/Mocks/MockModelContext.swift
+++ b/Weather-DVTTests/Mocks/MockModelContext.swift
@@ -1,0 +1,58 @@
+//
+//  MockModelContext.swift
+//  Weather-DVTTests
+//
+//  Created by Sylvan  on 30/08/2025.
+//
+
+import Foundation
+import SwiftData
+@testable import Weather_DVT
+
+final class MockModelContext: ModelContextProtocol {
+    var shouldThrowOnFetchCountError = false
+    var shouldThrowOnSaveError = false
+    var mockCountResult = 0
+
+    private(set) var didCallFetch = false
+    private(set) var didCallFetchCount = false
+    private(set) var didCallInsert = false
+    private(set) var didCallDelete = false
+    private(set) var didCallSave = false
+    private(set) var insertedObjects: [any PersistentModel] = []
+    private(set) var deleteObjects: [any PersistentModel] = []
+
+    func fetch<T>(_ descriptor: FetchDescriptor<T>) throws -> [T] where T : PersistentModel {
+        didCallFetch = true
+        return []
+    }
+    
+    func fetchCount<T>(_ descriptor: FetchDescriptor<T>) throws -> Int where T : PersistentModel {
+        didCallFetchCount = true
+        if shouldThrowOnFetchCountError {
+            throw MockTestError.dummyError
+        }
+        return mockCountResult
+    }
+    
+    func insert<T>(_ model: T) where T : PersistentModel {
+        didCallInsert = true
+        insertedObjects.append(model)
+    }
+    
+    func delete<T>(_ model: T) where T : PersistentModel {
+        didCallDelete = true
+        deleteObjects.append(model)
+    }
+    
+    func save() throws {
+        didCallSave = true
+        if shouldThrowOnSaveError {
+            throw MockTestError.dummyError
+        }
+    }
+
+    func getInsertedObject<T>(ofType: T.Type) -> T? {
+        return insertedObjects.first { $0 is T } as? T
+    }
+}

--- a/Weather-DVTTests/Mocks/MockModelContext.swift
+++ b/Weather-DVTTests/Mocks/MockModelContext.swift
@@ -13,6 +13,7 @@ final class MockModelContext: ModelContextProtocol {
     var shouldThrowOnFetchCountError = false
     var shouldThrowOnSaveError = false
     var mockCountResult = 0
+    var mockFetchResult: [any PersistentModel] = []
 
     private(set) var didCallFetch = false
     private(set) var didCallFetchCount = false
@@ -24,9 +25,9 @@ final class MockModelContext: ModelContextProtocol {
 
     func fetch<T>(_ descriptor: FetchDescriptor<T>) throws -> [T] where T : PersistentModel {
         didCallFetch = true
-        return []
+        return mockFetchResult.compactMap { $0 as? T }
     }
-    
+
     func fetchCount<T>(_ descriptor: FetchDescriptor<T>) throws -> Int where T : PersistentModel {
         didCallFetchCount = true
         if shouldThrowOnFetchCountError {
@@ -34,17 +35,17 @@ final class MockModelContext: ModelContextProtocol {
         }
         return mockCountResult
     }
-    
+
     func insert<T>(_ model: T) where T : PersistentModel {
         didCallInsert = true
         insertedObjects.append(model)
     }
-    
+
     func delete<T>(_ model: T) where T : PersistentModel {
         didCallDelete = true
         deleteObjects.append(model)
     }
-    
+
     func save() throws {
         didCallSave = true
         if shouldThrowOnSaveError {

--- a/Weather-DVTTests/Mocks/MockModels.swift
+++ b/Weather-DVTTests/Mocks/MockModels.swift
@@ -9,17 +9,7 @@ import Foundation
 @testable import Weather_DVT
 
 extension Weather {
-    static func mock() -> Weather {
-        .init(
-            date: .now,
-            main: "clear",
-            currentTempInCelcius: 25,
-            minTempInCelcius: 19,
-            maxTempInCelcius: 26
-        )
-    }
-
-    static func mock(main: String?) -> Weather {
+    static func mock(main: String? = "clear") -> Weather {
         .init(
             date: .now,
             main: main,
@@ -49,12 +39,50 @@ extension Forecast {
 }
 
 extension CachedLocation {
-    static func mock(name: String) -> CachedLocation {
+    static func mock(id: UUID = UUID(), name: String, isCurrent: Bool = false) -> CachedLocation {
         .init(
+            id: id,
             name: name,
             region: "",
             latitude: 1,
-            longitude: 1
+            longitude: 1,
+            isCurrentUserLocation: isCurrent
+        )
+    }
+}
+
+extension WeatherLocation {
+    static func mock(kind: WeatherLocation.Kind) -> WeatherLocation {
+        .init(
+            id: UUID().uuidString,
+            name: "Test",
+            region: "",
+            latitude: 1,
+            longitude: 1,
+            kind: kind
+        )
+    }
+}
+
+extension CachedCurrentWeather {
+    static func mock() -> CachedCurrentWeather {
+        .init(
+            currentTempCelcius: 20,
+            minTempCelcius: 18,
+            maxTempCelcius: 23,
+            main: "rainy"
+        )
+    }
+}
+
+extension CachedForecastWeather {
+    static func mock() -> CachedForecastWeather {
+        .init(
+            currentTempCelcius: 19,
+            minTempCelcius: 15,
+            maxTempCelcius: 21,
+            main: "clouds",
+            date: .now
         )
     }
 }

--- a/Weather-DVTTests/Mocks/MockModels.swift
+++ b/Weather-DVTTests/Mocks/MockModels.swift
@@ -1,5 +1,5 @@
 //
-//  Weather.swift
+//  MockModels.swift
 //  Weather-DVTTests
 //
 //  Created by Sylvan  on 28/08/2025.
@@ -44,6 +44,17 @@ extension Forecast {
                     maxTempInCelcius: 26
                 )
             ]
+        )
+    }
+}
+
+extension CachedLocation {
+    static func mock(name: String) -> CachedLocation {
+        .init(
+            name: name,
+            region: "",
+            latitude: 1,
+            longitude: 1
         )
     }
 }

--- a/Weather-DVTTests/Models/CurrentWeatherResponseTests.swift
+++ b/Weather-DVTTests/Models/CurrentWeatherResponseTests.swift
@@ -1,0 +1,56 @@
+//
+//  CurrentWeatherResponseTests.swift
+//  Weather-DVTTests
+//
+//  Created by Sylvan  on 30/08/2025.
+//
+
+import Foundation
+import Testing
+@testable import Weather_DVT
+
+struct CurrentWeatherResponseTests {
+    let decoder = JSONDecoder()
+
+    @Test("Successfully decodes from valid JSON")
+    func testDecodingSuccess() throws {
+        let sut = try decoder.decode(
+            CurrentWeatherResponse.self,
+            from: MockAPIData.currentWeatherJSON
+        )
+        #expect(sut.date == 1661870592)
+    }
+
+    @Test("`toDomain` method maps all properties correctly")
+    func testToDomainMapping() throws {
+        let sut = try decoder.decode(
+            CurrentWeatherResponse.self,
+            from: MockAPIData.currentWeatherJSON
+        )
+
+        // act
+        let domainModel = sut.toDomain()
+
+        // assert
+        #expect(domainModel.main == "Snow")
+        #expect(domainModel.currentTempInCelcius == 25.45)
+        #expect(domainModel.minTempInCelcius == 22.1)
+        #expect(domainModel.maxTempInCelcius == 28.9)
+        #expect(domainModel.date == Date(timeIntervalSince1970: 1661870592))
+    }
+
+    @Test("`toDomain` handles an empty weather array gracefully")
+    func testToDomainEmptyWeatherArray() throws {
+        // use the edge-case JSON
+        let sut = try decoder.decode(
+            CurrentWeatherResponse.self,
+            from: MockAPIData.currentWeatherEmptyWeatherArrayJSON
+        )
+
+        // act
+        let domainModel = sut.toDomain()
+
+        // assert
+        #expect(domainModel.main == nil, "The main condition should be nil when the weather array is empty")
+    }
+}

--- a/Weather-DVTTests/Models/Forecast5DaysResponseTests.swift
+++ b/Weather-DVTTests/Models/Forecast5DaysResponseTests.swift
@@ -1,0 +1,44 @@
+//
+//  Forecast5DaysResponseTests.swift
+//  Weather-DVTTests
+//
+//  Created by Sylvan  on 30/08/2025.
+//
+
+import Foundation
+import Testing
+@testable import Weather_DVT
+
+struct Forecast5DaysResponseTests {
+    let decoder = JSONDecoder()
+
+    @Test("Successfully decodes from valid forecast JSON")
+    func testDecodingSuccess() throws {
+        let jsonData = MockAPIData.forecast5DaysJSON
+
+        // act
+        let sut = try decoder.decode(Forecast5DaysResponse.self, from: jsonData)
+
+        // assert
+        #expect(sut.city.name == "Mountain View")
+        #expect(sut.list.count == 2, "The list should contain 2 forecast items")
+        #expect(sut.list.first?.date == 1661870592)
+    }
+
+    @Test("`toDomain` method maps the entire forecast object correctly")
+    func testToDomainMapping() throws {
+        let sut = try decoder.decode(Forecast5DaysResponse.self, from: MockAPIData.forecast5DaysJSON)
+
+        // act
+        let domainModel = sut.toDomain()
+
+        // assert
+        #expect(domainModel.city == "Mountain View")
+        #expect(domainModel.list.count == 2)
+
+        // Spot-check the first mapped item to ensure the nested mapping worked
+        let firstItem = domainModel.list.first
+        #expect(firstItem?.main == "Atmosphere")
+        #expect(firstItem?.currentTempInCelcius == 25.45)
+    }
+}

--- a/Weather-DVTTests/Services/DefaultPersistenceServiceTests.swift
+++ b/Weather-DVTTests/Services/DefaultPersistenceServiceTests.swift
@@ -12,11 +12,11 @@ import Testing
 @MainActor
 struct DefaultPersistenceServiceTests {
     var sut: DefaultPersistenceService!
-    var mockModelContext: MockModelContext!
+    var modelContext: MockModelContext!
 
     init() {
-        mockModelContext = MockModelContext()
-        sut = DefaultPersistenceService(modelContext: mockModelContext)
+        modelContext = MockModelContext()
+        sut = DefaultPersistenceService(modelContext: modelContext)
     }
 
     @Test("findOrCreateLocation returns nil for temporary locations")
@@ -28,7 +28,7 @@ struct DefaultPersistenceServiceTests {
 
         // assert
         #expect(result == nil, "Should return nil for temporary locations")
-        #expect(mockModelContext.insertedObjects.isEmpty, "Should not insert anything for a temporary location")
+        #expect(modelContext.insertedObjects.isEmpty, "Should not insert anything for a temporary location")
     }
 
     @Test("findOrCreateLocation fetches and returns an existing 'saved' location")
@@ -36,46 +36,46 @@ struct DefaultPersistenceServiceTests {
         let locationID = UUID()
         let savedLocation = WeatherLocation.mock(kind: .saved(persistenceModelID: locationID))
         let existingCache = CachedLocation.mock(id: locationID, name: "Test")
-        mockModelContext.mockFetchResult = [existingCache]
+        modelContext.mockFetchResult = [existingCache]
 
         // act
         let result = sut.fetchCachedWeather(for: savedLocation)
 
         // assert
         #expect(result?.id == locationID, "Should return the fetched location")
-        #expect(mockModelContext.didCallFetch)
-        #expect(mockModelContext.insertedObjects.isEmpty, "Should not insert a new location for saved location")
+        #expect(modelContext.didCallFetch)
+        #expect(modelContext.insertedObjects.isEmpty, "Should not insert a new location for saved location")
     }
 
     @Test("findOrCreateLocation fetches and returns an existing 'current' location")
     func testFindForExistingCurrentLocation() {
         let currentLocation = WeatherLocation.mock(kind: .current)
         let existingCache = CachedLocation.mock(name: "Test", isCurrent: true)
-        mockModelContext.mockFetchResult = [existingCache]
+        modelContext.mockFetchResult = [existingCache]
 
         // act
         let result = sut.fetchCachedWeather(for: currentLocation)
 
         // assert
         #expect(result?.isCurrentUserLocation == true, "Should return the correct 'current' location")
-        #expect(mockModelContext.didCallFetch)
-        #expect(mockModelContext.insertedObjects.isEmpty, "Should not insert a new location if one is found")
+        #expect(modelContext.didCallFetch)
+        #expect(modelContext.insertedObjects.isEmpty, "Should not insert a new location if one is found")
     }
 
     @Test("findOrCreateLocation CREATES a 'current' location if none exists")
     func testCreate_ForNewCurrentLocation() {
         let currentLocation = WeatherLocation.mock(kind: .current)
-        mockModelContext.mockFetchResult = []
+        modelContext.mockFetchResult = []
 
         // act
         let result = sut.fetchCachedWeather(for: currentLocation)
 
         // assert
-        let inserted = mockModelContext.getInsertedObject(ofType: CachedLocation.self)
+        let inserted = modelContext.getInsertedObject(ofType: CachedLocation.self)
         #expect(result != nil, "A new location should have been created and returned")
-        #expect(mockModelContext.didCallFetch)
-        #expect(mockModelContext.didCallInsert)
-        #expect(mockModelContext.insertedObjects.count == 1, "A new location should have been inserted into the context")
+        #expect(modelContext.didCallFetch)
+        #expect(modelContext.didCallInsert)
+        #expect(modelContext.insertedObjects.count == 1, "A new location should have been inserted into the context")
         #expect(inserted?.isCurrentUserLocation == true, "The new location should be marked as the current user's location")
         #expect(inserted?.latitude == currentLocation.latitude)
         #expect(inserted?.longitude == currentLocation.longitude)
@@ -87,7 +87,7 @@ struct DefaultPersistenceServiceTests {
         let existingWeather = CachedCurrentWeather.mock()
         let existingCache = CachedLocation.mock(name: "Test")
         existingCache.weather = existingWeather
-        mockModelContext.mockFetchResult = [existingCache]
+        modelContext.mockFetchResult = [existingCache]
 
         let freshWeather = Weather.mock()
 
@@ -97,14 +97,14 @@ struct DefaultPersistenceServiceTests {
         // assert
         #expect(existingCache.weather?.currentTempCelcius == freshWeather.currentTempInCelcius, "The temperature should be updated to the new value")
         #expect(existingCache.weather?.main == freshWeather.main, "The condition should be updated")
-        #expect(mockModelContext.didCallSave, "The context should be saved after updating")
+        #expect(modelContext.didCallSave, "The context should be saved after updating")
     }
 
     @Test("updateCache for weather creates a new entry")
     func testUpdateCacheCurrentWeatherCreatesNew() {
         let location = WeatherLocation.mock(kind: .current)
         let existingCache = CachedLocation.mock(name: "Test")
-        mockModelContext.mockFetchResult = [existingCache]
+        modelContext.mockFetchResult = [existingCache]
 
         let freshWeather = Weather.mock()
 
@@ -114,7 +114,7 @@ struct DefaultPersistenceServiceTests {
         // assert
         #expect(existingCache.weather?.currentTempCelcius == freshWeather.currentTempInCelcius, "The temperature should be updated to the new value")
         #expect(existingCache.weather?.main == freshWeather.main, "The condition should be updated")
-        #expect(mockModelContext.didCallSave, "The context should be saved after updating")
+        #expect(modelContext.didCallSave, "The context should be saved after updating")
     }
 
     @Test("updateCache for forecast updates existing forecast")
@@ -123,7 +123,7 @@ struct DefaultPersistenceServiceTests {
         let oldForecastDay = CachedForecastWeather.mock()
         let existingCache = CachedLocation.mock(name: "Test")
         existingCache.forecast = [oldForecastDay]
-        mockModelContext.mockFetchResult = [existingCache]
+        modelContext.mockFetchResult = [existingCache]
 
         let newForecastSummaries = [
             Weather.mock(main: "thunderstorm"),
@@ -137,6 +137,6 @@ struct DefaultPersistenceServiceTests {
         #expect(existingCache.forecast.count == 2, "The forecast should now contain 2 new items")
         #expect(existingCache.forecast.first?.main == "thunderstorm", "The first forecast item should be the new data")
         #expect(existingCache.forecast.contains(where: { $0.main == oldForecastDay.main }) == false, "The old forecast data should be gone")
-        #expect(mockModelContext.didCallSave, "The context should be saved after updating")
+        #expect(modelContext.didCallSave, "The context should be saved after updating")
     }
 }

--- a/Weather-DVTTests/Services/DefaultPersistenceServiceTests.swift
+++ b/Weather-DVTTests/Services/DefaultPersistenceServiceTests.swift
@@ -1,0 +1,142 @@
+//
+//  DefaultPersistenceServiceTests.swift
+//  Weather-DVTTests
+//
+//  Created by Sylvan  on 30/08/2025.
+//
+
+import Foundation
+import Testing
+@testable import Weather_DVT
+
+@MainActor
+struct DefaultPersistenceServiceTests {
+    var sut: DefaultPersistenceService!
+    var mockModelContext: MockModelContext!
+
+    init() {
+        mockModelContext = MockModelContext()
+        sut = DefaultPersistenceService(modelContext: mockModelContext)
+    }
+
+    @Test("findOrCreateLocation returns nil for temporary locations")
+    func testFindForTemporaryLocation() {
+        let tempLocation = WeatherLocation.mock(kind: .temporary)
+
+        // act
+        let result = sut.fetchCachedWeather(for: tempLocation)
+
+        // assert
+        #expect(result == nil, "Should return nil for temporary locations")
+        #expect(mockModelContext.insertedObjects.isEmpty, "Should not insert anything for a temporary location")
+    }
+
+    @Test("findOrCreateLocation fetches and returns an existing 'saved' location")
+    func testFindForExistingSavedLocation() {
+        let locationID = UUID()
+        let savedLocation = WeatherLocation.mock(kind: .saved(persistenceModelID: locationID))
+        let existingCache = CachedLocation.mock(id: locationID, name: "Test")
+        mockModelContext.mockFetchResult = [existingCache]
+
+        // act
+        let result = sut.fetchCachedWeather(for: savedLocation)
+
+        // assert
+        #expect(result?.id == locationID, "Should return the fetched location")
+        #expect(mockModelContext.didCallFetch)
+        #expect(mockModelContext.insertedObjects.isEmpty, "Should not insert a new location for saved location")
+    }
+
+    @Test("findOrCreateLocation fetches and returns an existing 'current' location")
+    func testFindForExistingCurrentLocation() {
+        let currentLocation = WeatherLocation.mock(kind: .current)
+        let existingCache = CachedLocation.mock(name: "Test", isCurrent: true)
+        mockModelContext.mockFetchResult = [existingCache]
+
+        // act
+        let result = sut.fetchCachedWeather(for: currentLocation)
+
+        // assert
+        #expect(result?.isCurrentUserLocation == true, "Should return the correct 'current' location")
+        #expect(mockModelContext.didCallFetch)
+        #expect(mockModelContext.insertedObjects.isEmpty, "Should not insert a new location if one is found")
+    }
+
+    @Test("findOrCreateLocation CREATES a 'current' location if none exists")
+    func testCreate_ForNewCurrentLocation() {
+        let currentLocation = WeatherLocation.mock(kind: .current)
+        mockModelContext.mockFetchResult = []
+
+        // act
+        let result = sut.fetchCachedWeather(for: currentLocation)
+
+        // assert
+        let inserted = mockModelContext.getInsertedObject(ofType: CachedLocation.self)
+        #expect(result != nil, "A new location should have been created and returned")
+        #expect(mockModelContext.didCallFetch)
+        #expect(mockModelContext.didCallInsert)
+        #expect(mockModelContext.insertedObjects.count == 1, "A new location should have been inserted into the context")
+        #expect(inserted?.isCurrentUserLocation == true, "The new location should be marked as the current user's location")
+        #expect(inserted?.latitude == currentLocation.latitude)
+        #expect(inserted?.longitude == currentLocation.longitude)
+    }
+
+    @Test("updateCache for weather updates an existing cache entry")
+    func testUpdateCacheCurrentWeatherUpdatesExisting() {
+        let location = WeatherLocation.mock(kind: .current)
+        let existingWeather = CachedCurrentWeather.mock()
+        let existingCache = CachedLocation.mock(name: "Test")
+        existingCache.weather = existingWeather
+        mockModelContext.mockFetchResult = [existingCache]
+
+        let freshWeather = Weather.mock()
+
+        // act
+        sut.updateCache(for: location, with: freshWeather)
+
+        // assert
+        #expect(existingCache.weather?.currentTempCelcius == freshWeather.currentTempInCelcius, "The temperature should be updated to the new value")
+        #expect(existingCache.weather?.main == freshWeather.main, "The condition should be updated")
+        #expect(mockModelContext.didCallSave, "The context should be saved after updating")
+    }
+
+    @Test("updateCache for weather creates a new entry")
+    func testUpdateCacheCurrentWeatherCreatesNew() {
+        let location = WeatherLocation.mock(kind: .current)
+        let existingCache = CachedLocation.mock(name: "Test")
+        mockModelContext.mockFetchResult = [existingCache]
+
+        let freshWeather = Weather.mock()
+
+        // act
+        sut.updateCache(for: location, with: freshWeather)
+
+        // assert
+        #expect(existingCache.weather?.currentTempCelcius == freshWeather.currentTempInCelcius, "The temperature should be updated to the new value")
+        #expect(existingCache.weather?.main == freshWeather.main, "The condition should be updated")
+        #expect(mockModelContext.didCallSave, "The context should be saved after updating")
+    }
+
+    @Test("updateCache for forecast updates existing forecast")
+    func testUpdateCacheForecastReplacesExisting() {
+        let location = WeatherLocation.mock(kind: .current)
+        let oldForecastDay = CachedForecastWeather.mock()
+        let existingCache = CachedLocation.mock(name: "Test")
+        existingCache.forecast = [oldForecastDay]
+        mockModelContext.mockFetchResult = [existingCache]
+
+        let newForecastSummaries = [
+            Weather.mock(main: "thunderstorm"),
+            Weather.mock(main: "clear")
+        ]
+
+        // act
+        sut.updateCache(for: location, with: newForecastSummaries)
+
+        // assert
+        #expect(existingCache.forecast.count == 2, "The forecast should now contain 2 new items")
+        #expect(existingCache.forecast.first?.main == "thunderstorm", "The first forecast item should be the new data")
+        #expect(existingCache.forecast.contains(where: { $0.main == oldForecastDay.main }) == false, "The old forecast data should be gone")
+        #expect(mockModelContext.didCallSave, "The context should be saved after updating")
+    }
+}

--- a/Weather-DVTTests/Services/WeatherEndpointTests.swift
+++ b/Weather-DVTTests/Services/WeatherEndpointTests.swift
@@ -1,0 +1,33 @@
+//
+//  WeatherEndpointTests.swift
+//  Weather-DVTTests
+//
+//  Created by Sylvan  on 30/08/2025.
+//
+
+import Foundation
+import Testing
+@testable import Weather_DVT
+
+@MainActor
+struct WeatherEndpointTests {
+    @Test("path")
+    func testPath() {
+        #expect(WeatherEndpoint.current(lat: 0, lon: 0).path == "/data/2.5/weather")
+        #expect(WeatherEndpoint.forecast5Days(lat: 0, lon: 0).path == "/data/2.5/forecast")
+    }
+
+    @Test("parameters")
+    func testParameters() {
+        let currentParameters = WeatherEndpoint.current(lat: 0, lon: 0).parameters
+        let forecastParameters = WeatherEndpoint.forecast5Days(lat: 0, lon: 0).parameters
+        #expect(currentParameters?.keys.contains("lat") == true)
+        #expect(currentParameters?.keys.contains("lon") == true)
+        #expect(currentParameters?.keys.contains("units") == true)
+        #expect(currentParameters?["lat"] as? Double == 0)
+        #expect(forecastParameters?.keys.contains("lat") == true)
+        #expect(forecastParameters?["lat"] as? Double == 0)
+        #expect(forecastParameters?.keys.contains("lon") == true)
+        #expect(forecastParameters?.keys.contains("units") == true)
+    }
+}

--- a/Weather-DVTTests/ViewModels/LocationsViewModelTests.swift
+++ b/Weather-DVTTests/ViewModels/LocationsViewModelTests.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import Testing
-import SwiftData
 @testable import Weather_DVT
 
 @MainActor
@@ -24,8 +23,12 @@ struct LocationsViewModelTests {
     }
 
     @Test("empty search")
-    func testEmptySearch() {
+    func testEmptySearch() async {
         sut.searchText = ""
+
+        // wait for a duration longer than the debounce
+        try? await Task.sleep(for: .milliseconds(400))
+
         #expect(sut.searchResults.isEmpty)
         #expect(sut.errorMessage == nil)
     }
@@ -155,7 +158,7 @@ struct LocationsViewModelTests {
     @Test("delete locations sets error message when database action fails")
     func testDeleteLocationsFail() {
         modelContext.shouldThrowOnSaveError = true
-        
+
         let offsets: IndexSet = [0]
         let allLocations = [CachedLocation.mock(name: "Nairobi")]
         sut.deleteLocations(at: offsets, from: allLocations)

--- a/Weather-DVTTests/ViewModels/LocationsViewModelTests.swift
+++ b/Weather-DVTTests/ViewModels/LocationsViewModelTests.swift
@@ -14,27 +14,24 @@ import SwiftData
 struct LocationsViewModelTests {
     var sut: LocationsView.ViewModel!
     var searchService: MockMapSearchService!
-    var modelContext: ModelContext!
+    var modelContext: MockModelContext!
     let location = SearchLocation(name: "Nairobi", region: "", coordinate: .init(latitude: 1, longitude: 1))
 
     init() {
-        let config = ModelConfiguration(isStoredInMemoryOnly: true)
-        let container = try! ModelContainer(for: CachedLocation.self, configurations: config)
-        modelContext = container.mainContext
-
+        modelContext = MockModelContext()
         searchService = MockMapSearchService()
         sut = .init(mapService: searchService, modelContext: modelContext)
     }
 
     @Test("empty search")
-    func emptySearch() {
+    func testEmptySearch() {
         sut.searchText = ""
         #expect(sut.searchResults.isEmpty)
         #expect(sut.errorMessage == nil)
     }
 
     @Test("search populates search results")
-    func searchPopulatesSearchResults() async {
+    func testSearchPopulatesSearchResults() async {
         searchService.searchResults = .success([location])
 
         let query = "Nai"
@@ -51,7 +48,7 @@ struct LocationsViewModelTests {
     }
 
     @Test("search sets error message on failure")
-    func searchSetsErrorMessageOnFailure() async {
+    func testSearchSetsErrorMessageOnFailure() async {
         searchService.searchResults = .failure(MockTestError.dummyError)
 
         let query = "Invalid"
@@ -65,7 +62,7 @@ struct LocationsViewModelTests {
     }
 
     @Test("navigate to result")
-    func navigateToResult() {
+    func testNavigateToResult() {
         #expect(sut.path.isEmpty, "Precondition: path should be empty.")
 
         sut.navigateToSearchResults(for: location)
@@ -74,7 +71,7 @@ struct LocationsViewModelTests {
     }
 
     @Test("navigation appends to exising path")
-    func navigationAppendsToExisingPath() {
+    func testNavigationAppendsToExisingPath() {
         let location2 = SearchLocation(name: "Mombasa", region: "", coordinate: .init(latitude: 2, longitude: 2))
         #expect(sut.path.isEmpty, "Precondition: path should be empty.")
 
@@ -87,21 +84,84 @@ struct LocationsViewModelTests {
         #expect(sut.path.count == 2, "Path should contain 2 elements")
     }
 
-    @Test("add location creates a new database entry")
-    func addLocationCreatesANewDatabaseEntry() async {
-        // TODO: test currently fails when trying to fetch from context
-//        sut.addLocation(location)
-//
-//        let descriptor = FetchDescriptor<CachedLocation>()
-//        let savedLocations = try! modelContext.fetch(descriptor)
-//
-//        #expect(savedLocations.count == 1)
-//        #expect(savedLocations.first?.name == "Nairobi")
-//        #expect(sut.searchText.isEmpty, "Search text should be cleared after adding a location")
+    @Test("add location creates a new unique database entry")
+    func testAddLocationWhenUniqueEntry() {
+        modelContext.mockCountResult = 0
+        sut.searchText = "Nair"
+
+        sut.addLocation(location)
+
+        let inserted = modelContext.getInsertedObject(ofType: CachedLocation.self)
+        #expect(sut.searchText == "", "Search text should be reset")
+        #expect(sut.errorMessage == nil, "Error message should be nil on success")
+        #expect(modelContext.didCallFetchCount)
+        #expect(modelContext.didCallInsert)
+        #expect(modelContext.didCallSave)
+        #expect(inserted != nil, "A CachedLocation object should be inserted")
+        #expect(inserted?.name == location.name)
     }
 
-    @Test("delete location")
-    func deleteLocation() async {
-        // TODO:
+    @Test("add location does not create a duplicate")
+    func testAddLocationWhenDuplicate() async {
+        modelContext.mockCountResult = 1
+        sut.searchText = "Nair"
+
+        sut.addLocation(location)
+
+        #expect(sut.searchText == "", "Search text should be reset")
+        #expect(sut.errorMessage == nil, "Error message should be nil regardless")
+        #expect(modelContext.didCallFetchCount)
+        #expect(modelContext.didCallInsert == false)
+        #expect(modelContext.didCallSave == false)
+        #expect(modelContext.insertedObjects.isEmpty, "No object should be created when a duplicate is found")
+    }
+
+    @Test("add location sets error message when database action fails")
+    func testAddLocationWhenDatabaseFails() {
+        modelContext.shouldThrowOnFetchCountError = true
+        sut.searchText = "Nair"
+
+        sut.addLocation(location)
+
+        #expect(sut.searchText == "Nair")
+        #expect(sut.errorMessage != nil)
+        #expect(modelContext.didCallFetchCount)
+        #expect(modelContext.didCallInsert == false)
+        #expect(modelContext.didCallSave == false)
+        #expect(modelContext.insertedObjects.isEmpty)
+    }
+
+    @Test("delete locations removes the correct items")
+    func testDeleteLocationsSuccess() async {
+        let allLocations = [
+            CachedLocation.mock(name: "Nairobi"),
+            CachedLocation.mock(name: "Mumbai"),
+            CachedLocation.mock(name: "Mombasa"),
+        ]
+        let offsets: IndexSet = [0, 2]
+
+        sut.deleteLocations(at: offsets, from: allLocations)
+
+        let deletedNames = modelContext.deleteObjects
+            .compactMap { $0 as? CachedLocation }
+            .map { $0.name }
+        #expect(modelContext.didCallDelete)
+        #expect(modelContext.didCallSave)
+        #expect(deletedNames == ["Nairobi", "Mombasa"])
+        #expect(modelContext.deleteObjects.count == 2)
+        #expect(sut.errorMessage == nil)
+    }
+
+    @Test("delete locations sets error message when database action fails")
+    func testDeleteLocationsFail() {
+        modelContext.shouldThrowOnSaveError = true
+        
+        let offsets: IndexSet = [0]
+        let allLocations = [CachedLocation.mock(name: "Nairobi")]
+        sut.deleteLocations(at: offsets, from: allLocations)
+
+        #expect(modelContext.didCallDelete)
+        #expect(modelContext.didCallSave)
+        #expect(sut.errorMessage != nil)
     }
 }


### PR DESCRIPTION
Changes:
- Make `MainContext` conform to a protocol for easier test mocking
- Add unit tests for adding and deleting locations in Locations-ViewModel
- Add unit tests for `PersistenceService`
- Add unit tests for `WeatherEndpoint`
- Add unit tests for DTO models: `CurrentWeatherResponse` and `Forecast5DaysResponse`